### PR TITLE
Resolve dev server 404 when refreshing

### DIFF
--- a/bin/webpack.dev.js
+++ b/bin/webpack.dev.js
@@ -21,6 +21,7 @@ module.exports = {
     open: true,
     port: 3000,
     allowedHosts: "all",
+    historyApiFallback: true,
   },
   entry: "./src/" + getEntry(),
   module: {

--- a/bin/webpack.dev.js
+++ b/bin/webpack.dev.js
@@ -23,6 +23,9 @@ module.exports = {
     allowedHosts: "all",
     historyApiFallback: true,
   },
+  output: {
+    publicPath: '/',
+  },
   entry: "./src/" + getEntry(),
   module: {
     rules: [


### PR DESCRIPTION
The webpack dev server will throw 404 not found when refreshing on non-root routes. Configure the fallback option to resolve it.