### PR TITLE
Set a public path, to allow for bundles to work in directories other than the root.

### DIFF
--- a/bin/webpack.prod.js
+++ b/bin/webpack.prod.js
@@ -59,7 +59,8 @@ module.exports = {
     new Dotenv({ silent: true })
   ],
   output: {
-    filename: '/[fullhash].bundle.js',
-    path: path.resolve(__dirname, '../../../build')
+    filename: '[fullhash].bundle.js',
+    path: path.resolve(__dirname, '../../../build'),
+    publicPath: "/"
   }
 }

--- a/bin/webpack.prod.js
+++ b/bin/webpack.prod.js
@@ -59,7 +59,7 @@ module.exports = {
     new Dotenv({ silent: true })
   ],
   output: {
-    filename: '[fullhash].bundle.js',
+    filename: '/[fullhash].bundle.js',
     path: path.resolve(__dirname, '../../../build')
   }
 }

--- a/bin/webpack.prodByDate.js
+++ b/bin/webpack.prodByDate.js
@@ -68,7 +68,7 @@ module.exports = {
     new Dotenv({ silent: true })
   ],
   output: {
-    filename: '[fullhash].bundle.js',
+    filename: '/[fullhash].bundle.js',
     path: path.resolve(__dirname, `../../../build/${getFormattedDate()}`)
   }
 }

--- a/bin/webpack.prodByDate.js
+++ b/bin/webpack.prodByDate.js
@@ -68,7 +68,8 @@ module.exports = {
     new Dotenv({ silent: true })
   ],
   output: {
-    filename: '/[fullhash].bundle.js',
-    path: path.resolve(__dirname, `../../../build/${getFormattedDate()}`)
+    filename: '[fullhash].bundle.js',
+    path: path.resolve(__dirname, `../../../build/${getFormattedDate()}`),
+    publicPath: "/"
   }
 }


### PR DESCRIPTION
I recently migrated some of my sites from create-react-app to R3F-Pack, which has worked well so far, but I recently found one issue. When I tried to use my router system to access a "page" from another directory (I don't actually have files there), it failed, as the bundle would try to load from the same directory.

A simple fix to this, was to set a public path in the webpack.

This fix simply sets that public path (in a non-ideal manner) to the value of `/` so that it can state that the site functions at the root directory. Not a perfect solution, but a workable one.